### PR TITLE
Fix Ltac done can prove what original tactic does.

### DIFF
--- a/sflib.v
+++ b/sflib.v
@@ -66,7 +66,7 @@ Ltac done := unfold not in *; trivial with sflib; hnf; intros;
          try sflib__basic_done; split; 
          try sflib__basic_done; split; 
          try sflib__basic_done; split; sflib__basic_done
-    | match goal with H : ~ _ |- _ => solve [case H; trivial] end].
+    | match goal with H : _ -> False |- _ => solve [case H; trivial] end].
 
 (** A variant of the ssr "done" tactic that performs "eassumption". *)
 


### PR DESCRIPTION
Fix `Ltac done` to prove Prop like following (which can be proved by original `done` tactic).

``` coq
forall P, ~(5=5) -> P
```
