### PR TITLE
Support coq 8.11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,12 @@ _CoqProject
 Makefile.coq
 .coqdeps.d
 Makefile.coq.conf
+.Makefile.coq.d
 
 .*.aux
 *.vo
 *.vio
+*.vok
+*.vos
 *.v.d
 *.glob


### PR DESCRIPTION
@jeehoonkang 
This PR supports coq 8.11
- replace deprecated flag `quick` with `vio`
- ignore generated files as [here](https://github.com/vafeiadis/hahn/commit/4bb0982197b6355d9dbf85534dd2955c636d1918)