### PR TITLE
Fix deprecated tactics for Coq 8.18

### DIFF
--- a/sflib.v
+++ b/sflib.v
@@ -723,7 +723,8 @@ Tactic Notation "extensionalities" ident(a) ident(b) ident(c) ident(d) ident(e) 
 
 (* short for common tactics *)
 
-Tactic Notation "inst" := instantiate.
+(* Deprecated in Coq 8.18 *)
+(* Tactic Notation "inst" := instantiate. *)
 Tactic Notation "econs" := econstructor.
 Tactic Notation "econs" int_or_var(x) := econstructor x.
 Tactic Notation "i" := intros.
@@ -787,16 +788,28 @@ Ltac clear_upto H :=
 
 Definition _Evar_sflib_ (A:Type) (x:A) := x.
 
-Tactic Notation "hide_evar" int_or_var(n) := let QQ := fresh "QQ" in
-  hget_evar n; intro;
-  lazymatch goal with [ H := ?X |- _] =>
-    set (QQ := X) in *; fold (_Evar_sflib_ X) in QQ; clear H
+(* Deprecated in Coq 8.18 *)
+(* Tactic Notation "hide_evar" int_or_var(n) := let QQ := fresh "QQ" in *)
+(*  hget_evar n; intro;                                                 *)
+(*  lazymatch goal with [ H := ?X |- _] =>                              *)
+(*    set (QQ := X) in *; fold (_Evar_sflib_ X) in QQ; clear H          *)
+(*  end.                                                                *)
+
+Ltac hide_evars :=
+  repeat match goal with
+  | [ |- context [?x] ] => is_evar x; set x;
+    lazymatch goal with [ H := x |- _ ] =>
+      fold (_Evar_sflib_ x) in H
+    end
   end.
 
-Ltac hide_evars := repeat (hide_evar 1).
-
-Ltac show_evars := repeat (match goal with [ H := @_Evar_sflib_ _ _ |- _ ] => unfold
- _Evar_sflib_ in H; unfold H in *; clear H end).
+Ltac show_evars :=
+  repeat match goal with
+  | [ H := @_Evar_sflib_ _ _ |- _ ] =>
+    unfold _Evar_sflib_ in H;
+    unfold H in *;
+    clear H
+  end.
 
 Ltac revert1 := match goal with [H: _|-_] => revert H end.
 


### PR DESCRIPTION
In Coq 8.18, `instantiate` without arguments are forbidden and the tactic `hget_evar` was erased.
Since installation from opam no longer works, I tried to fix them as much as possible.
Hopefully no-one was using these tactics...